### PR TITLE
[HotFix] 보안 취약점 스캐닝, 크롤링 방지 임시 조치

### DIFF
--- a/terraform/common/alb/https-listener/main.tf
+++ b/terraform/common/alb/https-listener/main.tf
@@ -5,8 +5,13 @@ resource "aws_alb_listener" "https" {
   certificate_arn   = var.https_listener.certificate_arn
 
   default_action {
-    type             = var.https_listener.type
-    target_group_arn = var.https_listener.default_target_group_arn
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access Denied: Invalid Host"
+      status_code  = "403"
+    }
   }
 }
 


### PR DESCRIPTION
## ✨ 개요
- Datadog SLO 알람에서 지속적으로 레이턴시가 감소하고 있다는 경고가 발생해 임시 조치를 적용했습니다.
- ALB에서 서버 도메인으로만 접근이 가능하게 리스너 규칙을 수정합니다.
- 임시적으로 스캐닝과 크롤링을 줄일수 있지만 시간이 지나고, 도메인이 노출되면 다시 공격이 들어올 가능성이 높기에 반드시 추가 조치가 필요합니다.

## 🧾 관련 이슈
#196
 
## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * ALB HTTPS 리스너의 기본 동작이 유효하지 않은/미지정 호스트 요청에 대해 대상 그룹 전달 대신 HTTP 403과 “Access Denied: Invalid Host” 메시지를 반환합니다. 잘못된 도메인 접근 시 사용자에게 명확한 거부 사유가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->