### PR TITLE
[Refactor] SLO에 영향을 미치는 쿼리 개선 작업

### DIFF
--- a/src/main/java/eatda/domain/cheer/Cheer.java
+++ b/src/main/java/eatda/domain/cheer/Cheer.java
@@ -49,6 +49,12 @@ public class Cheer extends AuditingEntity {
     @OneToMany(mappedBy = "cheer", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<CheerImage> images = new HashSet<>();
 
+    /*
+    CheerTags가 Embedded이기 때문에 BatchSize를 그대로 적용하지 못함.
+    성능을 위해서는 Embedded 제거 후 직접 @OneToMany로 매핑 필요함.
+    현재 데이터가 많지 않음으로 현상 유지하며 모니터링.
+    추후 재설계 필요
+     */
     @Embedded
     private CheerTags cheerTags;
 

--- a/src/main/java/eatda/domain/store/Store.java
+++ b/src/main/java/eatda/domain/store/Store.java
@@ -57,6 +57,12 @@ public class Store extends AuditingEntity {
     @Embedded
     private Coordinates coordinates;
 
+    /*
+    현재는 가게당 평균 응원 수가 5개 이하이므로 BatchSize=10이 적절함.
+    IN 쿼리 한 번당 최대 10개 Store의 Cheer를 로딩하도록 설정.
+    향후 응원 수가 증가하거나 Store 리스트 조회 규모가 커질 경우
+    성능 모니터링 후 BatchSize 조정 및 Fetch 전략 재검토 필요.
+    */
     @OneToMany(mappedBy = "store")
     private List<Cheer> cheers = new ArrayList<>();
 

--- a/src/main/java/eatda/domain/story/Story.java
+++ b/src/main/java/eatda/domain/story/Story.java
@@ -24,6 +24,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Table(name = "story")
 @Entity
@@ -35,6 +36,7 @@ public class Story extends AuditingEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @BatchSize(size = 10)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -58,6 +60,7 @@ public class Story extends AuditingEntity {
     @Column(name = "description")
     private String description;
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "story", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StoryImage> images = new ArrayList<>();
 

--- a/src/main/java/eatda/domain/story/Story.java
+++ b/src/main/java/eatda/domain/story/Story.java
@@ -24,7 +24,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 
 @Table(name = "story")
 @Entity
@@ -36,7 +35,6 @@ public class Story extends AuditingEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @BatchSize(size = 10)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -60,7 +58,6 @@ public class Story extends AuditingEntity {
     @Column(name = "description")
     private String description;
 
-    @BatchSize(size = 10)
     @OneToMany(mappedBy = "story", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StoryImage> images = new ArrayList<>();
 

--- a/src/main/java/eatda/repository/cheer/CheerRepository.java
+++ b/src/main/java/eatda/repository/cheer/CheerRepository.java
@@ -8,19 +8,18 @@ import eatda.domain.store.Store;
 import eatda.domain.store.StoreCategory;
 import jakarta.persistence.criteria.JoinType;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.Nullable;
 
 public interface CheerRepository extends JpaRepository<Cheer, Long> {
 
-    @EntityGraph(attributePaths = {"member", "cheerTags.values"})
-    List<Cheer> findAllByStoreOrderByCreatedAtDesc(Store store, PageRequest pageRequest);
+    Page<Cheer> findAllByStoreOrderByCreatedAtDesc(Store store, PageRequest pageRequest);
 
-    default List<Cheer> findAllByConditions(@Nullable StoreCategory category,
+    default Page<Cheer> findAllByConditions(@Nullable StoreCategory category,
                                             List<CheerTagName> cheerTagNames,
                                             List<District> districts, Pageable pageable) {
         Specification<Cheer> spec = createSpecification(category, cheerTagNames, districts);
@@ -36,7 +35,9 @@ public interface CheerRepository extends JpaRepository<Cheer, Long> {
         }
         if (!cheerTagNames.isEmpty()) {
             spec = spec.and(((root, query, cb) -> {
-                query.distinct(true);
+                if (query != null) {
+                    query.distinct(true);
+                }
                 return root.join("cheerTags").join("values", JoinType.LEFT)
                         .get("name").in(cheerTagNames);
             }));
@@ -47,8 +48,7 @@ public interface CheerRepository extends JpaRepository<Cheer, Long> {
         return spec;
     }
 
-    @EntityGraph(attributePaths = {"store", "member", "cheerTags.values"})
-    List<Cheer> findAll(Specification<Cheer> specification, Pageable pageable);
+    Page<Cheer> findAll(Specification<Cheer> specification, Pageable pageable);
 
     int countByMember(Member member);
 

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -41,6 +41,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         return findAll(spec, pageable);
     }
 
+    // Querydsl등을 이용하여 EntityGraph와 Limit 분리 필요
     @EntityGraph(attributePaths = {"cheers"})
     List<Store> findAll(Specification<Store> spec, Pageable pageable);
 

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -8,9 +8,9 @@ import eatda.exception.BusinessErrorCode;
 import eatda.exception.BusinessException;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.lang.Nullable;
@@ -33,7 +33,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
             """)
     List<Store> findAllByCheeredMemberId(long memberId);
 
-    default List<Store> findAllByConditions(@Nullable StoreCategory category,
+    default Page<Store> findAllByConditions(@Nullable StoreCategory category,
                                             List<CheerTagName> cheerTagNames,
                                             List<District> districts,
                                             Pageable pageable) {
@@ -41,9 +41,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         return findAll(spec, pageable);
     }
 
-    // Querydsl등을 이용하여 EntityGraph와 Limit 분리 필요
-    @EntityGraph(attributePaths = {"cheers"})
-    List<Store> findAll(Specification<Store> spec, Pageable pageable);
+    Page<Store> findAll(Specification<Store> spec, Pageable pageable);
 
     private Specification<Store> createSpecification(@Nullable StoreCategory category,
                                                      List<CheerTagName> cheerTagNames,
@@ -53,8 +51,12 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("category"), category));
         }
         if (!cheerTagNames.isEmpty()) {
-            spec = spec.and(((root, query, cb) ->
-                    root.join("cheers").join("cheerTags").join("values").get("name").in(cheerTagNames)));
+            spec = spec.and(((root, query, cb) -> {
+                if (query != null) {
+                    query.distinct(true);
+                }
+                return root.join("cheers").join("cheerTags").join("values").get("name").in(cheerTagNames);
+            }));
         }
         if (!districts.isEmpty()) {
             spec = spec.and((root, query, cb) -> root.get("district").in(districts));

--- a/src/main/java/eatda/repository/story/StoryRepository.java
+++ b/src/main/java/eatda/repository/story/StoryRepository.java
@@ -3,15 +3,12 @@ package eatda.repository.story;
 import eatda.domain.story.Story;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
-    @EntityGraph(attributePaths = "images")
     Page<Story> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<Story> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "images"})
     Page<Story> findAllByStoreKakaoIdOrderByCreatedAtDesc(String storeKakaoId, Pageable pageable);
 }

--- a/src/main/java/eatda/service/store/StoreService.java
+++ b/src/main/java/eatda/service/store/StoreService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -45,7 +46,7 @@ public class StoreService {
     // TODO : N+1 문제 해결
     @Transactional(readOnly = true)
     public StoresResponse getStores(StoreSearchParameters parameters) {
-        List<Store> stores = storeRepository.findAllByConditions(
+        Page<Store> stores = storeRepository.findAllByConditions(
                 parameters.getCategory(),
                 parameters.getCheerTagNames(),
                 parameters.getDistricts(),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,6 +27,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        default_batch_fetch_size: 30
 
   flyway:
     enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,6 +22,7 @@ spring:
       max-file-size: 5MB
       max-request-size: 20MB
 
+  # BatchSize 미적용시를 비교하기 위해 local에는 BatchSize를 추가하지 않음
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        default_batch_fetch_size: 30
 
   flyway:
     enabled: true

--- a/src/test/java/eatda/repository/cheer/CheerRepositoryTest.java
+++ b/src/test/java/eatda/repository/cheer/CheerRepositoryTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 class CheerRepositoryTest extends BaseRepositoryTest {
@@ -64,7 +65,7 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             Cheer cheer2_2 = cheerGenerator.generateCommon(member2, store2);
             Cheer cheer3_2 = cheerGenerator.generateCommon(member2, store3);
 
-            List<Cheer> actual = cheerRepository.findAllByConditions(
+            Page<Cheer> actual = cheerRepository.findAllByConditions(
                     StoreCategory.KOREAN, List.of(), List.of(), Pageable.unpaged());
 
             assertThat(actual).map(Cheer::getId)
@@ -90,7 +91,7 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer2_2, List.of(CheerTagName.CLEAN_RESTROOM));
             cheerTagGenerator.generate(cheer3_1, List.of(CheerTagName.ENERGETIC, CheerTagName.QUIET));
 
-            List<Cheer> actual = cheerRepository.findAllByConditions(null,
+            Page<Cheer> actual = cheerRepository.findAllByConditions(null,
                     List.of(CheerTagName.INSTAGRAMMABLE, CheerTagName.CLEAN_RESTROOM), List.of(), Pageable.unpaged());
 
             assertThat(actual)
@@ -110,7 +111,7 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             Cheer cheer2_2 = cheerGenerator.generateCommon(member2, store2);
             Cheer cheer3_2 = cheerGenerator.generateCommon(member2, store3);
 
-            List<Cheer> actual = cheerRepository.findAllByConditions(
+            Page<Cheer> actual = cheerRepository.findAllByConditions(
                     null, List.of(), List.of(District.GANGNAM), Pageable.unpaged());
 
             assertThat(actual)
@@ -145,7 +146,7 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer4_2, List.of(CheerTagName.INSTAGRAMMABLE));
             cheerTagGenerator.generate(cheer5_2, List.of(CheerTagName.CLEAN_RESTROOM, CheerTagName.ENERGETIC));
 
-            List<Cheer> actual = cheerRepository.findAllByConditions(StoreCategory.KOREAN,
+            Page<Cheer> actual = cheerRepository.findAllByConditions(StoreCategory.KOREAN,
                     List.of(CheerTagName.CLEAN_RESTROOM), List.of(District.GANGNAM), Pageable.unpaged());
 
             assertThat(actual)
@@ -169,7 +170,7 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer2_1, List.of(CheerTagName.CLEAN_RESTROOM));
             cheerTagGenerator.generate(cheer2_2, List.of(CheerTagName.CLEAN_RESTROOM));
 
-            List<Cheer> actual = cheerRepository.findAllByConditions(null, List.of(), List.of(), Pageable.unpaged());
+            Page<Cheer> actual = cheerRepository.findAllByConditions(null, List.of(), List.of(), Pageable.unpaged());
 
             assertThat(actual)
                     .map(Cheer::getId)

--- a/src/test/java/eatda/repository/store/StoreRepositoryTest.java
+++ b/src/test/java/eatda/repository/store/StoreRepositoryTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 class StoreRepositoryTest extends BaseRepositoryTest {
@@ -61,7 +62,7 @@ class StoreRepositoryTest extends BaseRepositoryTest {
             Store store2 = storeGenerator.generate("1236", "서울시 강남구 역삼동 123-45", StoreCategory.WESTERN, startAt);
             Store store3 = storeGenerator.generate("1237", "서울시 강남구 역삼동 123-45", StoreCategory.KOREAN, startAt);
 
-            List<Store> actual = storeRepository.findAllByConditions(
+            Page<Store> actual = storeRepository.findAllByConditions(
                     StoreCategory.KOREAN, List.of(), List.of(), Pageable.unpaged());
 
             assertThat(actual).map(Store::getId)
@@ -87,7 +88,7 @@ class StoreRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer2_2, List.of(CheerTagName.CLEAN_RESTROOM));
             cheerTagGenerator.generate(cheer3_1, List.of(CheerTagName.ENERGETIC, CheerTagName.QUIET));
 
-            List<Store> actual = storeRepository.findAllByConditions(null,
+            Page<Store> actual = storeRepository.findAllByConditions(null,
                     List.of(CheerTagName.INSTAGRAMMABLE, CheerTagName.CLEAN_RESTROOM), List.of(), Pageable.unpaged());
 
             assertThat(actual).map(Store::getId)
@@ -100,7 +101,7 @@ class StoreRepositoryTest extends BaseRepositoryTest {
             Store store2 = storeGenerator.generate("1236", "서울시 강남구 역삼동 123-45", District.GANGNAM);
             Store store3 = storeGenerator.generate("1237", "서울시 성북구 석관동 123-45", District.SEONGBUK);
 
-            List<Store> actual = storeRepository.findAllByConditions(
+            Page<Store> actual = storeRepository.findAllByConditions(
                     null, List.of(), List.of(District.GANGNAM), Pageable.unpaged());
 
             assertThat(actual).map(Store::getId)
@@ -134,7 +135,7 @@ class StoreRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer4_2, List.of(CheerTagName.INSTAGRAMMABLE));
             cheerTagGenerator.generate(cheer5_2, List.of(CheerTagName.CLEAN_RESTROOM, CheerTagName.ENERGETIC));
 
-            List<Store> actual = storeRepository.findAllByConditions(StoreCategory.KOREAN,
+            Page<Store> actual = storeRepository.findAllByConditions(StoreCategory.KOREAN,
                     List.of(CheerTagName.CLEAN_RESTROOM), List.of(District.GANGNAM), Pageable.unpaged());
 
             assertThat(actual).map(Store::getId)
@@ -157,7 +158,7 @@ class StoreRepositoryTest extends BaseRepositoryTest {
             cheerTagGenerator.generate(cheer2_1, List.of(CheerTagName.CLEAN_RESTROOM));
             cheerTagGenerator.generate(cheer2_2, List.of(CheerTagName.CLEAN_RESTROOM));
 
-            List<Store> actual = storeRepository.findAllByConditions(null, List.of(), List.of(), Pageable.unpaged());
+            Page<Store> actual = storeRepository.findAllByConditions(null, List.of(), List.of(), Pageable.unpaged());
 
             assertThat(actual).map(Store::getId)
                     .containsExactlyInAnyOrder(store1.getId(), store2.getId(), store3.getId());

--- a/terraform/common/waf/main.tf
+++ b/terraform/common/waf/main.tf
@@ -85,32 +85,32 @@ resource "aws_wafv2_web_acl" "this" {
     statement {
       or_statement {
         statement {
-          size_constraint_statement {
+          byte_match_statement {
             field_to_match {
               single_header {
                 name = "origin"
               }
             }
-            comparison_operator = "GT"
-            size                = 0
+            search_string         = "eatda.net"
+            positional_constraint = "ENDS_WITH"
             text_transformation {
               priority = 0
-              type     = "NONE"
+              type     = "LOWERCASE"
             }
           }
         }
         statement {
-          size_constraint_statement {
+          byte_match_statement {
             field_to_match {
               single_header {
                 name = "referer"
               }
             }
-            comparison_operator = "GT"
-            size                = 0
+            search_string         = "eatda.net"
+            positional_constraint = "CONTAINS"
             text_transformation {
               priority = 0
-              type     = "NONE"
+              type     = "LOWERCASE"
             }
           }
         }

--- a/terraform/common/waf/main.tf
+++ b/terraform/common/waf/main.tf
@@ -114,6 +114,66 @@ resource "aws_wafv2_web_acl" "this" {
             }
           }
         }
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "origin"
+              }
+            }
+            search_string         = "dev.eatda.net"
+            positional_constraint = "ENDS_WITH"
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "referer"
+              }
+            }
+            search_string         = "dev.eatda.net"
+            positional_constraint = "CONTAINS"
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "origin"
+              }
+            }
+            search_string         = "http://localhost:3000"
+            positional_constraint = "EXACTLY"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = "referer"
+              }
+            }
+            search_string         = "http://localhost:3000/"
+            positional_constraint = "STARTS_WITH"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
       }
     }
     visibility_config {


### PR DESCRIPTION
## ✨ 개요

### SLO에 영향을 미치는 쿼리 성능 개선을 진행했습니다.
#### 🧩 문제 원인
- `EntityGraph` + `Pageable` 조합으로 인해 **인메모리 페이징**이 발생했습니다.
- JPA가 전체 데이터를 메모리로 로딩한 후 페이징을 적용하여  
  `/api/shop`, `/api/store`, `/api/cheer` API의 응답 지연으로 이어졌습니다.

#### 🛠️ 해결 방법
- `EntityGraph`를 유지하면서 **DB 레벨에서 페이징을 적용**하려면  
  쿼리 분리(Query Split) 또는 커스텀 QueryDSL 작성이 필요합니다.  
- 구조적 변경이 크기 때문에, 단기적으로는 `@BatchSize`를 활용하여  
  Lazy 로딩 시 발생하는 N+1 문제를 완화하고 **SLO 영향을 최소화**하는 방향으로 접근했습니다.

#### 📍 적용 범위
- `/api/shop`, `/api/store`, `/api/cheer` API의 `EntityGraph`를 제거하고 `Batch Fetch`를 적용했습니다.
- 실제 Prod 데이터 분석 결과, 연관 데이터 개수가 대부분 **10개 이하**로 나타났습니다.  
  → 최적 배치 크기는 10이지만, **향후 데이터 증가를 고려해 30으로 설정**했습니다.
- 아래는 배치 크기에 따른 테스트 결과입니다.

| 구분 | 배치 미적용 | 배치 크기 10 | 배치 크기 30 |
|------|--------------|---------------|---------------|
| **쿼리 실행 방식** | N+1 문제 발생 | Batch Fetch 적용 | Batch Fetch 적용 |
| **총 실행 쿼리 수** | 41개 | 5개 | 5개 |
| **평균 레이턴시** | 약 45ms | 약 20.5ms | 약 23.5ms |

- dev 환경에 우선 적용하였으며, 모니터링 후 prod 반영을 검토할 예정입니다.

---

### 🧱 WAF 브라우저 요청 허용 규칙 개선
- 허용된 도메인에서 온 요청만 통과하도록 **헤더 기반 검증 로직**을 강화했습니다.
- 로컬 → dev 환경 접근이 가능하도록 규칙을 조정했습니다.
- 클라이언트팀과 함께 테스트를 진행해 **정상 접근 가능**함을 확인했습니다.

---

## 🧾 관련 이슈
#205 #207

## 🔍 참고 사항
